### PR TITLE
Fix wasm output alias for 家人们

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: cargo build --release --features="binaries" --locked
 
       - name: Build wasm
+        env:
+          RUSTFLAGS: -C link-arg=--allow-undefined
         run: |
           rustup target add wasm32-unknown-unknown
           cargo build --bin wasm -Z unstable-options --profile tiny --target wasm32-unknown-unknown --features=wasm

--- a/src/wasm/main.rs
+++ b/src/wasm/main.rs
@@ -26,6 +26,13 @@ fn internal_print(msg: &str) {
     }
 }
 
+fn wasm_output(args: Vec<Object>) -> Object {
+    for arg in args {
+        internal_print(&format!("{}", arg));
+    }
+    Object::Null
+}
+
 fn string_to_ptr(s: String) -> *mut c_char {
     CString::new(s).unwrap().into_raw()
 }
@@ -76,15 +83,8 @@ pub fn eval(input_ptr: *mut c_char) -> *mut c_char {
 
     let mut env = Env::from(new_builtins());
 
-    env.set(
-        String::from("小作文"),
-        &Object::Builtin(-1, |args| {
-            for arg in args {
-                internal_print(&format!("{}", arg));
-            }
-            Object::Null
-        }),
-    );
+    env.set(String::from("小作文"), &Object::Builtin(-1, wasm_output));
+    env.set(String::from("家人们"), &Object::Builtin(-1, wasm_output));
 
     let mut evaluator = Evaluator::new(Rc::new(RefCell::new(env)));
     let evaluated = evaluator.eval(&program).unwrap_or(Object::Null);


### PR DESCRIPTION
## Summary
- route the wasm playground output alias 家人们 through the same browser print callback as 小作文
- reuse a shared wasm output builtin for both aliases

Fixes #45

## Tests
- cargo test
- cargo build --bin wasm --target wasm32-unknown-unknown --features=wasm
